### PR TITLE
Introduce AbstractElement and AbstractElementBuilder to reduce code duplication.

### DIFF
--- a/pumlgenerator/src/main/kotlin/uml/element/AbstractElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/AbstractElement.kt
@@ -23,6 +23,6 @@ $functionsString
     }
 
     override fun toString(): String {
-        return "AbstractElement(elementName=$elementName, elementAlias=$elementAlias, uniqueIdentifier=$uniqueIdentifier, attributes=${attributes.map { it.uniqueIdentifier }}, functions=${functions.map { it.uniqueIdentifier }}, isShell=$isShell)"
+        return "AbstractElement(elementName=$elementName, elementAlias=$elementAlias, uniqueIdentifier=$uniqueIdentifier, attributes=${attributes.map { it.uniqueIdentifier }}, functions=${functions.map { it.uniqueIdentifier }}, isShell=$isShell, elementKind=$elementKind)"
     }
 }

--- a/pumlgenerator/src/main/kotlin/uml/element/AbstractElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/AbstractElement.kt
@@ -1,0 +1,28 @@
+package uml.element
+
+import uml.DiagramElement
+import uml.ElementKind
+
+abstract class AbstractElement(override val elementName: String, override val elementAlias: String, val uniqueIdentifier: String, val attributes: List<Field>, val functions: List<Method>, val isShell: Boolean) : DiagramElement() {
+    override val comment: String = "'$uniqueIdentifier"
+    override fun getContent(indent: String): String {
+        val shellString = if (isShell) DiagramElement.shellString else ""
+        val attributesString = attributes
+            .takeIf { it.isNotEmpty() }
+            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
+            ?: ""
+        val functionsString = functions
+            .takeIf { it.isNotEmpty() }
+            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
+            ?: ""
+        return """
+$shellString
+$attributesString
+$functionsString
+        """
+    }
+
+    override fun toString(): String {
+        return "AbstractElement(elementName=$elementName, elementAlias=$elementAlias, uniqueIdentifier=$uniqueIdentifier, attributes=${attributes.map { it.uniqueIdentifier }}, functions=${functions.map { it.uniqueIdentifier }}, isShell=$isShell)"
+    }
+}

--- a/pumlgenerator/src/main/kotlin/uml/element/AbstractElementBuilder.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/AbstractElementBuilder.kt
@@ -1,0 +1,52 @@
+package uml.element
+
+import Options
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import filterFunctionsByOptions
+import filterPropertiesByOptions
+import uml.DiagramElement
+
+abstract class AbstractElementBuilder(override val clazz: KSClassDeclaration, override var isShell: Boolean, override val options: Options, val logger: KSPLogger? = null) : DiagramElement.Builder<AbstractElement> {
+    val companionObject = clazz.declarations.filter { it is KSClassDeclaration && it.isCompanionObject }.map { it as? KSClassDeclaration }.firstOrNull()
+
+    override val extensionProperties: MutableList<KSPropertyDeclaration> = mutableListOf()
+
+    override val allProperties: List<KSPropertyDeclaration>
+        get() = buildList {
+            if (!isShell) {
+                val validCompanionObjectProperties = companionObject?.getAllProperties()?.filterPropertiesByOptions(clazz, options, logger) ?: emptySequence()
+                addAll(validCompanionObjectProperties)
+
+                val validProperties = clazz.getAllProperties().filterPropertiesByOptions(clazz, options, logger)
+                addAll(validProperties)
+
+                val otherProperties = clazz.declarations.filterIsInstance<KSPropertyDeclaration>().filterNot { it in clazz.getAllProperties() }.filterPropertiesByOptions(clazz, options, logger)
+                addAll(otherProperties)
+            }
+
+            addAll(extensionProperties)
+        }.toMutableList()
+
+    override val extensionFunctions: MutableList<KSFunctionDeclaration> = mutableListOf()
+
+    override val allFunctions: List<KSFunctionDeclaration>
+        get() = buildList {
+            if (!isShell) {
+                val validCompanionObjectFunctions = companionObject?.getAllFunctions()?.filterFunctionsByOptions(clazz, options, logger) ?: emptySequence()
+                addAll(validCompanionObjectFunctions)
+
+                val validFunctions = clazz.getAllFunctions().filterFunctionsByOptions(clazz, options, logger)
+                addAll(validFunctions)
+
+                val otherFunctions = clazz.declarations.filterIsInstance<KSFunctionDeclaration>().filterNot { it in clazz.getAllFunctions() }.filterFunctionsByOptions(clazz, options, logger)
+                addAll(otherFunctions)
+            }
+
+            addAll(extensionFunctions)
+        }.toMutableList()
+
+    abstract override fun build(): AbstractElement?
+}

--- a/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
@@ -26,7 +26,7 @@ class ClassElement(
     isShell: Boolean
 ) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
 
-    override val elementKind: ElementKind = ElementKind.CLAZZ(isSealedClass, isData = isDataClass)
+    override val elementKind: ElementKind = ElementKind.CLAZZ(isSealed = isSealedClass, isData = isDataClass)
 
     class Builder(clazz: KSClassDeclaration, isShell: Boolean, options: Options, logger: KSPLogger? = null) : AbstractElementBuilder(clazz, isShell, options, logger) {
 

--- a/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
@@ -3,17 +3,11 @@ package uml.element
 import Options
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Modifier
-import filterFunctionsByOptions
-import filterPropertiesByOptions
 import isValid
-import uml.DiagramElement
 import uml.ElementKind
 import uml.className
 import uml.fullQualifiedName
-import java.util.Collections.addAll
 
 class ClassElement(
     elementName: String,

--- a/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/ClassElement.kt
@@ -15,74 +15,20 @@ import uml.className
 import uml.fullQualifiedName
 import java.util.Collections.addAll
 
-data class ClassElement(
-    override val elementName: String,
-    override val elementAlias: String,
-    val uniqueIdentifier: String,
-    val attributes: List<Field>,
-    val functions: List<Method>,
+class ClassElement(
+    elementName: String,
+    elementAlias: String,
+    uniqueIdentifier: String,
+    attributes: List<Field>,
+    functions: List<Method>,
     val isSealedClass: Boolean,
     val isDataClass: Boolean,
-    val isShell: Boolean
-) : DiagramElement() {
-    override val comment: String = "'$uniqueIdentifier"
+    isShell: Boolean
+) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
+
     override val elementKind: ElementKind = ElementKind.CLAZZ(isSealedClass, isData = isDataClass)
-    override fun getContent(indent: String): String {
-        val shellString = if (isShell) DiagramElement.shellString else ""
-        val attributesString = attributes
-            .takeIf { it.isNotEmpty() }
-            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
-            ?: ""
-        val functionsString = functions
-            .takeIf { it.isNotEmpty() }
-            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
-            ?: ""
-        return """
-$shellString
-$attributesString
-$functionsString
-        """
-    }
 
-    class Builder(override val clazz: KSClassDeclaration, override var isShell: Boolean, override val options: Options, val logger: KSPLogger? = null) : DiagramElement.Builder<ClassElement> {
-        val companionObject = clazz.declarations.filter { it is KSClassDeclaration && it.isCompanionObject }.map { it as? KSClassDeclaration }.firstOrNull()
-
-        override val extensionProperties: MutableList<KSPropertyDeclaration> = mutableListOf()
-
-        override val allProperties: List<KSPropertyDeclaration>
-            get() = buildList {
-                if (!isShell) {
-                    val validCompanionObjectProperties = companionObject?.getAllProperties()?.filterPropertiesByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectProperties)
-
-                    val validProperties = clazz.getAllProperties().filterPropertiesByOptions(clazz, options, logger)
-                    addAll(validProperties)
-
-                    val otherProperties = clazz.declarations.filterIsInstance<KSPropertyDeclaration>().filterNot { it in clazz.getAllProperties() }.filterPropertiesByOptions(clazz, options, logger)
-                    addAll(otherProperties)
-                }
-
-                addAll(extensionProperties)
-            }.toMutableList()
-
-        override val extensionFunctions: MutableList<KSFunctionDeclaration> = mutableListOf()
-
-        override val allFunctions: List<KSFunctionDeclaration>
-            get() = buildList {
-                if (!isShell) {
-                    val validCompanionObjectFunctions = companionObject?.getAllFunctions()?.filterFunctionsByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectFunctions)
-
-                    val validFunctions = clazz.getAllFunctions().filterFunctionsByOptions(clazz, options, logger)
-                    addAll(validFunctions)
-
-                    val otherFunctions = clazz.declarations.filterIsInstance<KSFunctionDeclaration>().filterNot { it in clazz.getAllFunctions() }.filterFunctionsByOptions(clazz, options, logger)
-                    addAll(otherFunctions)
-                }
-
-                addAll(extensionFunctions)
-            }.toMutableList()
-
+    class Builder(clazz: KSClassDeclaration, isShell: Boolean, options: Options, logger: KSPLogger? = null) : AbstractElementBuilder(clazz, isShell, options, logger) {
 
         override fun build(): ClassElement? {
             return if (options.isValid(clazz, logger)) {
@@ -104,5 +50,6 @@ $functionsString
         override fun toString(): String {
             return "ClassBuilder(clazz=${clazz.fullQualifiedName})"
         }
+
     }
 }

--- a/pumlgenerator/src/main/kotlin/uml/element/EnumElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/EnumElement.kt
@@ -4,10 +4,6 @@ import Options
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import filterFunctionsByOptions
-import filterPropertiesByOptions
 import isValid
 import uml.DiagramElement
 import uml.ElementKind
@@ -15,16 +11,15 @@ import uml.className
 import uml.fullQualifiedName
 
 
-data class EnumElement(
-    val uniqueIdentifier: String,
-    override val elementName: String,
-    override val elementAlias: String,
-    val attributes: List<Field>,
-    val functions: List<Method>,
+class EnumElement(
+    uniqueIdentifier: String,
+    elementName: String,
+    elementAlias: String,
+    attributes: List<Field>,
+    functions: List<Method>,
     val members: List<String>,
-    val isShell: Boolean
-) : DiagramElement() {
-    override val comment: String = "'$uniqueIdentifier"
+    isShell: Boolean
+) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
     override val elementKind: ElementKind = ElementKind.ENUM
     override fun getContent(indent: String): String {
         val shellString = if (isShell) DiagramElement.shellString else ""
@@ -48,43 +43,7 @@ $functionsString
 """
     }
 
-    class Builder(override val clazz: KSClassDeclaration, override var isShell: Boolean, override val options: Options, val logger: KSPLogger?) : DiagramElement.Builder<EnumElement> {
-        val companionObject = clazz.declarations.filter { it is KSClassDeclaration && it.isCompanionObject }.map { it as? KSClassDeclaration }.firstOrNull()
-
-        override val extensionProperties: MutableList<KSPropertyDeclaration> = mutableListOf()
-
-        override val allProperties: MutableList<KSPropertyDeclaration>
-            get() = buildList {
-                if (!isShell) {
-                    val validCompanionObjectProperties = companionObject?.getAllProperties()?.filterPropertiesByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectProperties)
-
-                    val validProperties = clazz.getAllProperties().filterPropertiesByOptions(clazz, options, logger)
-                    addAll(validProperties)
-
-                    val otherProperties = clazz.declarations.filterIsInstance<KSPropertyDeclaration>().filterNot { it in clazz.getAllProperties() }.filterPropertiesByOptions(clazz, options, logger)
-                    addAll(otherProperties)
-                }
-
-                addAll(extensionProperties)
-            }.toMutableList()
-
-        override val extensionFunctions: MutableList<KSFunctionDeclaration> = mutableListOf()
-
-        override val allFunctions: MutableList<KSFunctionDeclaration>
-            get() = buildList {
-                if (!isShell) {
-                    val validCompanionObjectFunctions = companionObject?.getAllFunctions()?.filterFunctionsByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectFunctions)
-
-                    val validFunctions = clazz.getAllFunctions().filterFunctionsByOptions(clazz, options, logger)
-                    addAll(validFunctions)
-
-                    val otherFunctions = clazz.declarations.filterIsInstance<KSFunctionDeclaration>().filterNot { it in clazz.getAllFunctions() }.filterFunctionsByOptions(clazz, options, logger)
-                    addAll(otherFunctions)
-                }
-                addAll(extensionFunctions)
-            }.toMutableList()
+    class Builder(clazz: KSClassDeclaration, isShell: Boolean, options: Options, logger: KSPLogger?) : AbstractElementBuilder(clazz, isShell, options, logger) {
 
         override fun build(): EnumElement? {
             return if (options.isValid(clazz, logger)) {

--- a/pumlgenerator/src/main/kotlin/uml/element/EnumElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/EnumElement.kt
@@ -20,7 +20,9 @@ class EnumElement(
     val members: List<String>,
     isShell: Boolean
 ) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
+
     override val elementKind: ElementKind = ElementKind.ENUM
+
     override fun getContent(indent: String): String {
         val shellString = if (isShell) DiagramElement.shellString else ""
         val membersString = members

--- a/pumlgenerator/src/main/kotlin/uml/element/InterfaceElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/InterfaceElement.kt
@@ -3,13 +3,8 @@ package uml.element
 import Options
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Modifier
-import filterFunctionsByOptions
-import filterPropertiesByOptions
 import isValid
-import uml.DiagramElement
 import uml.ElementKind
 import uml.className
 import uml.fullQualifiedName

--- a/pumlgenerator/src/main/kotlin/uml/element/InterfaceElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/InterfaceElement.kt
@@ -23,6 +23,7 @@ class InterfaceElement(
     isSealedClass: Boolean,
     isShell: Boolean
 ) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
+
     override val elementKind: ElementKind = ElementKind.INTERFACE(isSealedClass)
 
     class Builder( clazz: KSClassDeclaration, isShell: Boolean,  options: Options, logger: KSPLogger?) : AbstractElementBuilder(clazz, isShell, options, logger) {

--- a/pumlgenerator/src/main/kotlin/uml/element/ObjectElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/ObjectElement.kt
@@ -13,71 +13,18 @@ import uml.ElementKind
 import uml.className
 import uml.fullQualifiedName
 
-data class ObjectElement(
-    val uniqueIdentifier: String,
-    override val elementName: String,
-    override val elementAlias: String,
-    val attributes: List<Field>,
-    val functions: List<Method>,
-    val isShell: Boolean
-) : DiagramElement() {
-    override val comment: String = "'$uniqueIdentifier"
+class ObjectElement(
+    uniqueIdentifier: String,
+    elementName: String,
+    elementAlias: String,
+    attributes: List<Field>,
+    functions: List<Method>,
+    isShell: Boolean
+) : AbstractElement(elementName, elementAlias, uniqueIdentifier, attributes, functions, isShell) {
+
     override val elementKind: ElementKind = ElementKind.OBJECT
-    override fun getContent(indent: String): String {
-        val shellString = if (isShell) DiagramElement.shellString else ""
-        val attributesString = attributes
-            .takeIf { it.isNotEmpty() }
-            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
-            ?: ""
-        val functionsString = functions
-            .takeIf { it.isNotEmpty() }
-            ?.let { it.joinToString(separator = "\n") { "$indent${it.render()}" } }
-            ?: ""
-        return """
-$shellString
-$attributesString
-$functionsString
-"""
-    }
 
-    class Builder(override val clazz: KSClassDeclaration, override var isShell: Boolean, override val options: Options, val logger: KSPLogger?) : DiagramElement.Builder<ObjectElement> {
-        val companionObject = clazz.declarations.filter { it is KSClassDeclaration && it.isCompanionObject }.map { it as? KSClassDeclaration }.firstOrNull()
-
-        override val extensionProperties: MutableList<KSPropertyDeclaration> = mutableListOf()
-
-        override val allProperties: MutableList<KSPropertyDeclaration>
-            get() = buildList {
-                if (!isShell) {
-
-                    val validCompanionObjectProperties = companionObject?.getAllProperties()?.filterPropertiesByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectProperties)
-
-                    val validProperties = clazz.getAllProperties().filterPropertiesByOptions(clazz, options, logger)
-                    addAll(validProperties)
-
-                    val otherProperties = clazz.declarations.filterIsInstance<KSPropertyDeclaration>().filterNot { it in clazz.getAllProperties() }.filterPropertiesByOptions(clazz, options, logger)
-                    addAll(otherProperties)
-                }
-                addAll(extensionProperties)
-            }.toMutableList()
-
-        override val extensionFunctions: MutableList<KSFunctionDeclaration> = mutableListOf()
-
-        override val allFunctions: MutableList<KSFunctionDeclaration>
-            get() = buildList {
-                if (!isShell) {
-
-                    val validCompanionObjectFunctions = companionObject?.getAllFunctions()?.filterFunctionsByOptions(clazz, options, logger) ?: emptySequence()
-                    addAll(validCompanionObjectFunctions)
-
-                    val validFunctions = clazz.getAllFunctions().filterFunctionsByOptions(clazz, options, logger)
-                    addAll(validFunctions)
-
-                    val otherFunctions = clazz.declarations.filterIsInstance<KSFunctionDeclaration>().filterNot { it in clazz.getAllFunctions() }.filterFunctionsByOptions(clazz, options, logger)
-                    addAll(otherFunctions)
-                }
-                addAll(extensionFunctions)
-            }.toMutableList()
+    class Builder(clazz: KSClassDeclaration, isShell: Boolean, options: Options, logger: KSPLogger?) : AbstractElementBuilder(clazz, isShell, options, logger) {
 
         override fun build(): ObjectElement? {
             return if (options.isValid(clazz, logger)) {

--- a/pumlgenerator/src/main/kotlin/uml/element/ObjectElement.kt
+++ b/pumlgenerator/src/main/kotlin/uml/element/ObjectElement.kt
@@ -3,12 +3,7 @@ package uml.element
 import Options
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import filterFunctionsByOptions
-import filterPropertiesByOptions
 import isValid
-import uml.DiagramElement
 import uml.ElementKind
 import uml.className
 import uml.fullQualifiedName


### PR DESCRIPTION
- Reduce Code duplication of `ClassElement`, `EnumElement`, `InterfaceElement` and `ObjectElement` by moving equal code logic into AbstractClass.